### PR TITLE
Fixed Menu Populate

### DIFF
--- a/Shell/Interop/User32.cs
+++ b/Shell/Interop/User32.cs
@@ -57,30 +57,30 @@ namespace GongSolutions.Shell.Interop
     [StructLayout(LayoutKind.Sequential)]
     public struct MENUINFO
     {
-        public int cbSize;
+        public UInt32 cbSize;
         public MIM fMask;
-        public int dwStyle;
-        public int cyMax;
+        public UInt32 dwStyle;
+        public UInt32 cyMax;
         public IntPtr hbrBack;
-        public int dwContextHelpID;
-        public int dwMenuData;
+        public UInt32 dwContextHelpID;
+        public UIntPtr dwMenuData;
     }
 
     [StructLayout(LayoutKind.Sequential)]
     public struct MENUITEMINFO
     {
-        public int cbSize;
+        public UInt32 cbSize;
         public MIIM fMask;
-        public uint fType;
-        public uint fState;
-        public int wID;
+        public UInt32 fType;
+        public UInt32 fState;
+        public UInt32 wID;
         public IntPtr hSubMenu;
-        public int hbmpChecked;
-        public int hbmpUnchecked;
-        public int dwItemData;
+        public IntPtr hbmpChecked;
+        public IntPtr hbmpUnchecked;
+        public UIntPtr dwItemData;
         public string dwTypeData;
-        public uint cch;
-        public int hbmpItem;
+        public UInt32 cch;
+        public IntPtr hbmpItem;
     }
 
     public enum MF

--- a/Shell/ShellContextMenu.cs
+++ b/Shell/ShellContextMenu.cs
@@ -323,9 +323,9 @@ namespace GongSolutions.Shell
         {
             MENUINFO info = new MENUINFO();
 
-            info.cbSize = Marshal.SizeOf(info);
+            info.cbSize = (UInt32)Marshal.SizeOf(info);
             info.fMask = MIM.MIM_MENUDATA;
-            info.dwMenuData = tag;
+            info.dwMenuData = (UIntPtr)tag;
 
             foreach (MenuItem item in menu.MenuItems)
             {
@@ -341,9 +341,9 @@ namespace GongSolutions.Shell
             MENUINFO menuInfo = new MENUINFO();
             MENUITEMINFO itemInfo = new MENUITEMINFO();
 
-            menuInfo.cbSize = Marshal.SizeOf(menuInfo);
+            menuInfo.cbSize = (UInt32)Marshal.SizeOf(menuInfo);
             menuInfo.fMask = MIM.MIM_MENUDATA;
-            itemInfo.cbSize = Marshal.SizeOf(itemInfo);
+            itemInfo.cbSize = (UInt32)Marshal.SizeOf(itemInfo);
             itemInfo.fMask = MIIM.MIIM_ID | MIIM.MIIM_SUBMENU;
 
             // First, tag the managed menu items with an arbitary 
@@ -363,7 +363,7 @@ namespace GongSolutions.Shell
                 else
                 {
                     User32.GetMenuInfo(itemInfo.hSubMenu, ref menuInfo);
-                    if (menuInfo.dwMenuData != tag) remove.Add(n);
+                    if ((int)menuInfo.dwMenuData != tag) remove.Add(n);
                 }
             }
 


### PR DESCRIPTION
Interop calls using MENUITEMINFO or MENUITEM parameters would fail due to incorrect struct member types.

To reproduce, Windows 8.1 64 bit, ShellExplorer Example, opening the File menu several times would result in shell menuitems being added to the menu multiple times. RemoveShellMenuItems did not remove any menu items.
